### PR TITLE
fix: create-markdown script to create file with .md extension

### DIFF
--- a/sveltekit-shadcn-v5/scripts/create-markdown.js
+++ b/sveltekit-shadcn-v5/scripts/create-markdown.js
@@ -11,7 +11,7 @@ const markdownsLocation = 'src/lib/resources/markdown';
 const locales = await getSubdirectories(markdownsLocation);
 const fileContent = getFileContent();
 for await (const locale of locales) {
-	const path = `${markdownsLocation}/${locale}/${inputPath}`;
+	const path = `${markdownsLocation}/${locale}/${inputPath}.md`;
 	await Bun.write(path, fileContent);
 }
 if (locales?.length > 0) {


### PR DESCRIPTION
Closes #24 