### PR TITLE
fix: keep switch in cookie manager always in ltr mode, tailwind

### DIFF
--- a/sveltekit-shadcn-v5/src/lib/components/ui/switch/switch.svelte
+++ b/sveltekit-shadcn-v5/src/lib/components/ui/switch/switch.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
 	import { Switch as SwitchPrimitive } from 'bits-ui';
 	import { cn, type WithoutChildrenOrChild } from '$lib/utils.js';
-	import { direction } from '$lib/stores';
 
 	let {
 		ref = $bindable(null),
@@ -24,7 +23,7 @@
 	<SwitchPrimitive.Thumb
 		data-slot="switch-thumb"
 		class={cn(
-			`bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:${$direction === 'lr' ? '' : '-'}translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0`
+			`bg-background dark:data-[state=unchecked]:bg-foreground dark:data-[state=checked]:bg-primary-foreground pointer-events-none block size-4 rounded-full ring-0 transition-transform data-[state=checked]:translate-x-[calc(100%-2px)] data-[state=unchecked]:translate-x-0`
 		)}
 	/>
 </SwitchPrimitive.Root>

--- a/sveltekit-shadcn-v5/src/routes/[[lang]]/(site)/manage-cookies/+page.svelte
+++ b/sveltekit-shadcn-v5/src/routes/[[lang]]/(site)/manage-cookies/+page.svelte
@@ -42,7 +42,7 @@
 			>
 				<section class="flex flex-row items-center justify-between">
 					<h2 class="mt-1 text-xl capitalize">{$t(`common.${cookieCategory['name']}`)}</h2>
-					<div class="flex items-center space-x-2">
+					<div class="flex items-center space-x-2" dir="ltr">
 						{#if cookieCategory['optional']}
 							<Switch
 								id={cookieCategory['name']}


### PR DESCRIPTION
limitation prevent change the checked state binded classes in runtime that includes arbitrary values